### PR TITLE
Fixed bug of no sound on first click

### DIFF
--- a/website/4x4.html
+++ b/website/4x4.html
@@ -127,11 +127,7 @@
     <!-- Boilerplate code starts from here -->
 
     <script>
-      update_loader_message("Loading Voice...");
-      var voices = speechSynthesis.getVoices();
-    </script>
-
-    <script>
+      window.speechSynthesis.onvoiceschanged = window.speechSynthesis.getVoices;
       const readAloud = function(rowNum) {
         rowNum = rowNum.toString();
         let toSay = "";

--- a/website/4x4.html
+++ b/website/4x4.html
@@ -123,8 +123,13 @@
     On subsequent runs, the modules it uses will already have been transpiled.
     It will go fast and any message you change will flash quickly.
     -->
-    <script type="text/javascript"> update_loader_message("Loading Program Code....") </script>
+    <script type="text/javascript"> update_loader_message("Loading Program Code...") </script>
     <!-- Boilerplate code starts from here -->
+
+    <script>
+      update_loader_message("Loading Voice...");
+      var voices = speechSynthesis.getVoices();
+    </script>
 
     <script>
       const readAloud = function(rowNum) {
@@ -134,7 +139,7 @@
           toSay = toSay + document.getElementById(rowNum + i.toString()).textContent
         }
         let utterance = new SpeechSynthesisUtterance(toSay);
-        utterance.voice = speechSynthesis.getVoices()[3]; // = Microsoft Huihui - Chinese (Simplified, PRC)
+        utterance.lang = "zh-CN";
         speechSynthesis.speak(utterance);
       };
     </script>


### PR DESCRIPTION
Edited 4x4.html according to advice found at:
- https://stackoverflow.com/questions/21513706/getting-the-list-of-voices-in-speechsynthesis-web-speech-api
- https://stackoverflow.com/questions/49506716/speechsynthesis-getvoices-returns-empty-array-on-windows
Added a script for loading the voices with speechSynthesis.getVoices() right when the page loads, such that the voices can be loaded in time for the first click of a read aloud button.